### PR TITLE
feat: Allow setting JSON decoding strictness and parser in loads

### DIFF
--- a/json_streamer/json.py
+++ b/json_streamer/json.py
@@ -5,9 +5,9 @@ from .parser import Parser, ParseState
 
 
 class JsonParser(Parser):
-    def __init__(self):
+    def __init__(self, strict: bool = True):
         super().__init__()
-        self._decoder = json.JSONDecoder()
+        self._decoder = json.JSONDecoder(strict=strict)
 
     @staticmethod
     def opening_symbols() -> List[chr]:
@@ -17,5 +17,9 @@ class JsonParser(Parser):
         return self._decoder.raw_decode(s)
 
 
-def loads(s: Optional[Generator[chr, None, None]] = None) -> Generator[Tuple[ParseState, dict], Optional[str], None]:
-    return JsonParser()(s)
+def loads(
+    s: Optional[Generator[chr, None, None]] = None,
+    parser: Optional[JsonParser] = None,
+) -> Generator[Tuple[ParseState, dict], Optional[str], None]:
+    parser = parser or JsonParser()
+    return parser(s)

--- a/tests/test_json_stream.py
+++ b/tests/test_json_stream.py
@@ -1,31 +1,60 @@
 import unittest
-from json_streamer import loads, ParseState
+from typing import Generator
+
+from json_streamer import JsonParser, ParseState, loads
 
 
-def stream_json():
-    json_string = '{"field1": "value1", "field2": 42}'
-    chunk_size = 4
-    for i in range(0, len(json_string), chunk_size):
-        yield json_string[i:i + chunk_size]
+def stream_json(value: str, chunk_size: int = 4) -> Generator[str, None, None]:
+    for i in range(0, len(value), chunk_size):
+        yield value[i:i + chunk_size]
 
 
 class TestStreamJson(unittest.TestCase):
 
+    TEST_CASES = (
+        {
+            'input': '{"field1": "value1", "field2": 42}',
+            'parse_fn': lambda s: loads(s),
+            'expected_states': [
+                (ParseState.PARTIAL, {'field1': ''}),
+                (ParseState.PARTIAL, {'field1': 'valu'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 4}),
+                (ParseState.COMPLETE, {'field1': 'value1', 'field2': 42})
+            ],
+        },
+        {
+            'input': '{"field1": "value1", "field2": "multi-line\n\nvalue"}',
+            'parse_fn': lambda s: loads(s),
+            'expected_states': [
+                (ParseState.PARTIAL, {'field1': ''}),
+                (ParseState.PARTIAL, {'field1': 'valu'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': ''}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'mult'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'multi-li'}),
+            ],
+        },
+        {
+            'input': '{"field1": "value1", "field2": "multi-line\n\nvalue"}',
+            'parse_fn': lambda s: loads(s, parser=JsonParser(strict=False)),
+            'expected_states': [
+                (ParseState.PARTIAL, {'field1': ''}),
+                (ParseState.PARTIAL, {'field1': 'valu'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': ''}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'mult'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'multi-li'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'multi-line\n\n'}),
+                (ParseState.PARTIAL, {'field1': 'value1', 'field2': 'multi-line\n\nvalu'}),
+                (ParseState.COMPLETE, {'field1': 'value1', 'field2': 'multi-line\n\nvalue'})
+            ],
+        },
+    )
+
     def test_stream_json(self):
-        mystream = stream_json()
-        ret = loads(mystream)
-
-        expected_states = [
-            (ParseState.PARTIAL, {'field1': ''}),
-            (ParseState.PARTIAL, {'field1': 'valu'}),
-            (ParseState.PARTIAL, {'field1': 'value1', 'field2': 4}),
-            (ParseState.COMPLETE, {'field1': 'value1', 'field2': 42})
-        ]
-
-        for i, (state, parsed_dict) in enumerate(ret):
-            expected_state, expected_dict = expected_states[i]
-            self.assertEqual(state, expected_state)
-            self.assertEqual(parsed_dict, expected_dict)
+        for test_case in self.TEST_CASES:
+            with self.subTest(test_case=test_case):
+                mystream = stream_json(test_case['input'])
+                ret = test_case['parse_fn'](mystream)
+                self.assertListEqual(list(ret), test_case['expected_states'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current default behavior of instantiating a `JSONDecoder` object is to be strict. This means that the parser will raise an exception if it encounters control characters in the input stream (like `\n` or `\t`).

Strings including control characters are common in LLM outputs, so this change allows the user to set the strictness of the parser when calling `loads`.

A simple way to use `loads` with a non-strict parser will be:

```python
from json_streamer import JsonParser, loads

mystream = stream_json()
ret = loads(mystream, parser=JsonParser(strict=False))
```